### PR TITLE
Do not overwrite scheme-wide colors with extend_highlight (#249)

### DIFF
--- a/colors/onedark.vim
+++ b/colors/onedark.vim
@@ -75,7 +75,7 @@ function! s:h(group, style, ...)
     let s:highlight = s:group_colors[a:group]
     for style_type in ["fg", "bg", "sp"]
       if (has_key(a:style, style_type))
-        let l:default_style = (has_key(s:highlight, style_type) ? s:highlight[style_type] : { "cterm16": "NONE", "cterm": "NONE", "gui": "NONE" })
+        let l:default_style = (has_key(s:highlight, style_type) ? copy(s:highlight[style_type]) : { "cterm16": "NONE", "cterm": "NONE", "gui": "NONE" })
         let s:highlight[style_type] = extend(l:default_style, a:style[style_type])
       endif
     endfor


### PR DESCRIPTION
Fixes #220

Create a copy of color dictionary and apply changes to it instead of
the original

Ex: If extend_highlight is called on a Highlight Group with default
purple foreground, don't overwrite values in the dictionary assigned to
purple.fg, e.g., {'gui': '#C678DD', 'cterm': '170', 'cterm16': '5'}.
Instead make a copy of the dictionary, apply changes to the copy, and
assign the altered copy to the user-specified Highlight Group.